### PR TITLE
Support older SQLite versions

### DIFF
--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -31,13 +31,14 @@ jobs:
         mv Cargo.toml wiring.rs/
         cd wiring.rs
         echo "mod python_module;" >> src/lib.rs
-        python3 -m venv .venv
-        source .venv/bin/activate
 
-    - name: Build using maturin and successfully run demo
+    - name: Run maturin develop
+      uses: messense/maturin-action@v1
+      with:
+        command: develop
+
+    - name: Successfully run demo
       run: |
-        pip install maturin
-        maturin develop
         cd ..
         python3 demo.py
         cd ..

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -14,22 +14,44 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out repository code
+      uses: actions/checkout@v3
+
+    - name: Setup wiring
+      run: |
+        git clone https://github.com/ontodev/wiring.py.git
+        cd wiring.py
+        git clone https://github.com/ontodev/wiring.rs.git
+        mv python_module.rs wiring.rs/src/
+        mv Cargo.toml wiring.rs/
+        cd wiring.rs
+        echo "mod python_module;" >> src/lib.rs
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Build using maturin and successfully run demo
+      run: |
+        pip install maturin
+        maturin develop
+        cd ..
+        python demo.py
+        cd ..
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install .
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
       run: |
         pytest -k sqlite

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -37,8 +37,8 @@ jobs:
       working-directory: ./wiring.py/wiring.rs
       run: |
         source .venv/bin/activate
-        pip3 install maturin
-        maturin --interpreter ${{ matrix.python-version }} develop
+        pip install -U pip maturin
+        maturin develop
 
     - name: Successfully run wiring demo
       working-directory: ./wiring.py
@@ -50,8 +50,8 @@ jobs:
       working-directory: .
       run: |
         source wiring.py/wiring.rs/.venv/bin/activate
-        pip3 install -r requirements.txt
-        pip3 install .
+        pip install -r requirements.txt
+        pip install .
 
     # - name: Lint with flake8
     #   working-directory: .

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -32,21 +32,20 @@ jobs:
         cd wiring.rs
         echo "mod python_module;" >> src/lib.rs
 
-    - name: Run maturin develop
-      uses: messense/maturin-action@v1
-      with:
-        command: develop
-
-    - name: Successfully run demo
+    - name: Build using maturin and successfully run demo
       run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip3 install maturin
+        maturin develop
         cd ..
         python3 demo.py
         cd ..
 
     - name: Install dependencies
       run: |
-        pip install -r requirements.txt
-        pip install .
+        pip3 install -r requirements.txt
+        pip3 install .
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -14,6 +14,11 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Check out repository code
       uses: actions/checkout@v3
 
@@ -26,18 +31,15 @@ jobs:
         mv Cargo.toml wiring.rs/
         cd wiring.rs
         echo "mod python_module;" >> src/lib.rs
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+        python3 -m venv .venv
+        source .venv/bin/activate
 
     - name: Build using maturin and successfully run demo
       run: |
         pip install maturin
         maturin develop
         cd ..
-        python demo.py
+        python3 demo.py
         cd ..
 
     - name: Install dependencies

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -54,12 +54,16 @@ jobs:
         pip3 install .
 
     - name: Lint with flake8
+      working-directory: .
       run: |
+        source wiring.py/wiring.rs/.venv/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
+      working-directory: .
       run: |
+        source wiring.py/wiring.rs/.venv/bin/activate
         pytest -k sqlite

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -33,20 +33,20 @@ jobs:
         echo "mod python_module;" >> src/lib.rs
         python3 -m venv .venv
 
-    - name: Build using maturin
+    - name: Build wiring using maturin
       working-directory: ./wiring.py/wiring.rs
       run: |
         source .venv/bin/activate
         pip3 install maturin
-        maturin develop
+        maturin --interpreter ${{ matrix.python-version }} develop
 
-    - name: Successfully run demo
+    - name: Successfully run wiring demo
       working-directory: ./wiring.py
       run: |
         source wiring.rs/.venv/bin/activate
         python3 demo.py
 
-    - name: Install dependencies
+    - name: Install gadget dependencies
       working-directory: .
       run: |
         source wiring.py/wiring.rs/.venv/bin/activate
@@ -62,7 +62,7 @@ jobs:
     #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Test with pytest
+    - name: Test gadget with sqlite and pytest
       working-directory: .
       run: |
         source wiring.py/wiring.rs/.venv/bin/activate

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -31,19 +31,25 @@ jobs:
         mv Cargo.toml wiring.rs/
         cd wiring.rs
         echo "mod python_module;" >> src/lib.rs
-
-    - name: Build using maturin and successfully run demo
-      run: |
         python3 -m venv .venv
+
+    - name: Build using maturin
+      working-directory: ./wiring.py/wiring.rs
+      run: |
         source .venv/bin/activate
         pip3 install maturin
         maturin develop
-        cd ..
+
+    - name: Successfully run demo
+      working-directory: ./wiring.py
+      run: |
+        source wiring.rs/.venv/bin/activate
         python3 demo.py
-        cd ..
 
     - name: Install dependencies
+      working-directory: .
       run: |
+        source wiring.py/wiring.rs/.venv/bin/activate
         pip3 install -r requirements.txt
         pip3 install .
 

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -53,14 +53,14 @@ jobs:
         pip3 install -r requirements.txt
         pip3 install .
 
-    - name: Lint with flake8
-      working-directory: .
-      run: |
-        source wiring.py/wiring.rs/.venv/bin/activate
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    # - name: Lint with flake8
+    #   working-directory: .
+    #   run: |
+    #     source wiring.py/wiring.rs/.venv/bin/activate
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
       working-directory: .

--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/gadget/sql.py
+++ b/gadget/sql.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 
@@ -128,13 +129,16 @@ def get_child_hierarchy(
     :param statement: name of ontology statement table
     :return dict of parent -> list of children
     """
-    query = f"""SELECT DISTINCT subject, object FROM "{statement}"
-        WHERE object IN :term_ids AND predicate IN ('rdfs:subClassOf', 'rdfs:subPropertyOf')"""
-    query = sql_text(query).bindparams(bindparam("term_ids", expanding=True))
-    results = conn.execute(query, term_ids=term_ids)
     descendants = defaultdict(list)
-    for res in results:
-        descendants[res["object"]].append(res["subject"])
+    # Use chunks to get around max SQL variables
+    chunks = [term_ids[i : i + MAX_SQL_VARS] for i in range(0, len(term_ids), MAX_SQL_VARS)]
+    for chunk in chunks:
+        query = f"""SELECT DISTINCT subject, object FROM "{statement}"
+            WHERE object IN :ids AND predicate IN ('rdfs:subClassOf', 'rdfs:subPropertyOf')"""
+        query = sql_text(query).bindparams(bindparam("ids", expanding=True))
+        results = conn.execute(query, {"ids": chunk})
+        for res in results:
+            descendants[res["object"]].append(res["subject"])
     return descendants
 
 def get_grandchild_hierarchy(
@@ -241,17 +245,20 @@ def get_entity_types(
     :param statement: name of ontology statement table
     :return: dict of term_id -> types
     """
-    query = sql_text(
-        f"""SELECT DISTINCT subject, object FROM "{statement}"
-            WHERE subject IN :term_ids AND predicate = 'rdf:type'"""
-    ).bindparams(bindparam("term_ids", expanding=True))
-    results = conn.execute(query, term_ids=term_ids).fetchall()
     all_types = defaultdict(list)
-    for res in results:
-        term_id = res["subject"]
-        if term_id not in all_types:
-            all_types[term_id] = list()
-        all_types[term_id].append(res["object"])
+    # Use chunks to get around max SQL variables
+    chunks = [term_ids[i : i + MAX_SQL_VARS] for i in range(0, len(term_ids), MAX_SQL_VARS)]
+    for chunk in chunks:
+        query = sql_text(
+            f"""SELECT DISTINCT subject, object FROM "{statement}"
+                WHERE subject IN :ids AND predicate = 'rdf:type'"""
+        ).bindparams(bindparam("ids", expanding=True))
+        results = conn.execute(query, {"ids": chunk})
+        for res in results:
+            term_id = res["subject"]
+            if term_id not in all_types:
+                all_types[term_id] = list()
+            all_types[term_id].append(res["object"])
 
     entity_types = {}
     for term_id, e_types in all_types.items():
@@ -425,8 +432,9 @@ def get_objects(
     results = []
     if term_ids:
         # Use chunks to get around max SQL variables
-        chunks = [term_ids[i : i + MAX_SQL_VARS] for i in range(0, len(term_ids), MAX_SQL_VARS)]
-        for chunk in chunks:
+        MAX = MAX_SQL_VARS - len(predicate_ids)
+        chunks = [term_ids[i : i + MAX] for i in range(0, len(term_ids), MAX)]
+        for i, chunk in enumerate(chunks):
             const_dict["terms"] = chunk
             query = query.bindparams(bindparam("terms", expanding=True))
             results.extend(conn.execute(query, const_dict).fetchall())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flake8
+flake8==5.0.4
 hiccupy==1.0.0
-pytest
-SQLAlchemy
-tabulate
+pytest==7.1.2
+SQLAlchemy==1.4.29
+tabulate==0.8.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flake8==5.0.4
 hiccupy==1.0.0
-pytest==7.1.2
+pytest==7
 SQLAlchemy==1.4.29
 tabulate==0.8.10


### PR DESCRIPTION
Older SQLite versions are limited to 999 variable substitutions. This update breaks most queries into chunks based on the number of variables required.